### PR TITLE
Implement lookup functions

### DIFF
--- a/src/Countries.jl
+++ b/src/Countries.jl
@@ -156,6 +156,7 @@ for (t, db, n) in ((:Country, :all_countries, :country), (:CountrySubdivision, :
         ```
         """
         function $f(field_name::Symbol, lookup_value)
+            field_name ∉ fieldnames($t) && throw(ArgumentError("Field $field_name does not exist for type $($t)"))
             i = findfirst($db) do x
                 v = getfield(x, field_name)
                 !isnothing(v) && v == lookup_value

--- a/src/Countries.jl
+++ b/src/Countries.jl
@@ -137,5 +137,32 @@ end
 
 const all_scripts = _parse_json(Script, "15924")
 
+### ISO LOOKUP FUNCTIONS
+
+for (t, db, n) in ((:Country, :all_countries, :country), (:CountrySubdivision, :all_country_subdivisions, :country_subdivision), (:Currency, :all_currencies, :currency), (:Language, :all_languages, :language), (:Script, :all_scripts, :script))
+    f = Symbol("lookup_$n")
+    @eval begin
+        export $f
+        
+        """
+            $($f)(field_name::Symbol, lookup_value)
+        
+        Find the first $($t) whose `field_name` has value `lookup_value`.
+        
+        # Example
+        
+        ```julia
+        $($f)(:name, "Some $($t) Name")
+        ```
+        """
+        function $f(field_name::Symbol, lookup_value)
+            i = findfirst($db) do x
+                v = getfield(x, field_name)
+                !isnothing(v) && v == lookup_value
+            end
+            return isnothing(i) ? i : $db[i]
+        end
+    end
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, Countries
 
-@testset "Countries" begin
+@testset "Countries.jl" begin
 
     # for code coverage (which doesn't measure things only run during precompile)
     Countries._parse_json(Countries.Country, "3166-1")
@@ -8,11 +8,20 @@ using Test, Countries
     Countries._parse_json(Countries.Currency, "4217")
     Countries._parse_json(Countries.Language, "639-3")
     Countries._parse_json(Countries.Script, "15924")
-
-    @test Countries.all_countries isa Vector{Countries.Country}
-    @test Countries.all_country_subdivisions isa Vector{Countries.CountrySubdivision}
-    @test Countries.all_currencies isa Vector{Countries.Currency}
-    @test Countries.all_languages isa Vector{Countries.Language}
-    @test Countries.all_scripts isa Vector{Countries.Script}
-
+    
+    @testset "ISO Lists" begin
+        @test Countries.all_countries isa Vector{Countries.Country}
+        @test Countries.all_country_subdivisions isa Vector{Countries.CountrySubdivision}
+        @test Countries.all_currencies isa Vector{Countries.Currency}
+        @test Countries.all_languages isa Vector{Countries.Language}
+        @test Countries.all_scripts isa Vector{Countries.Script}
+    end
+    
+    @testset "ISO Lookup" begin
+        @test Countries.lookup_country(:alpha2, "BE").flag == "🇧🇪"
+        @test Countries.lookup_country_subdivision(:code, "SC-18").name == "Mont Fleuri"
+        @test Countries.lookup_currency(:alpha3, "EUR").name == "Euro"
+        @test Countries.lookup_language(:alpha2, "cy").name == "Welsh"
+        @test Countries.lookup_script(:alpha4, "Hung").numeric == Int16(176)
+    end
 end


### PR DESCRIPTION
Often times this package may be used to get ISO-standard information about a single language or country, &c.  As such, I think it is valuable to have some lookup functions for each type exposed in this package.

I have implemented these lookup functions naïvely in this PR.

If you think this behaviour is simple enough for the user to implement themselves, then please disregard this PR.